### PR TITLE
💄 Design: TabTitle 컴포넌트 마크업 #37

### DIFF
--- a/src/components/TabTitle/TabTitle.jsx
+++ b/src/components/TabTitle/TabTitle.jsx
@@ -1,0 +1,108 @@
+/** @jsxImportSource @emotion/react */
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
+
+export default function TabTitle({ page = 'cart', isCheckBox = true }) {
+  const [isChecked, setIsChecked] = useState(false);
+
+  const handleCheckBoxClick = event => {
+    event.preventDefault();
+    setIsChecked(!isChecked);
+  };
+
+  const tabTitleList = {
+    cart: {
+      caption: '장바구니',
+      colgroup: (
+        <colgroup>
+          <col width="80" />
+        </colgroup>
+      ),
+      th: [
+        isCheckBox && (
+          <label>
+            <input
+              title="모든 상품을 결제상품으로 설정"
+              type="checkbox"
+              className="a11y-hidden"
+              checked={isChecked}
+              readOnly
+            />
+            <div css={allOrderSelectStyles} onClick={handleCheckBoxClick}>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+              >
+                <circle
+                  cx="10"
+                  cy="10"
+                  r="9"
+                  stroke="#21BF48"
+                  strokeWidth="2"
+                />
+                {isChecked && <circle cx="10" cy="10" r="6" fill="#21BF48" />}
+              </svg>
+            </div>
+          </label>
+        ),
+        '상품정보',
+        '수량',
+        '상품금액',
+      ],
+    },
+    order: {
+      caption: '주문내역',
+      th: ['상품정보', '할인', '배송비', '주문금액'],
+    },
+  };
+
+  return (
+    <>
+      <caption className="a11y-hidden">{tabTitleList[page].caption}</caption>
+      {tabTitleList[page].colgroup && tabTitleList[page].colgroup}
+      <thead>
+        <tr css={headTrStyles}>
+          {tabTitleList[page].th.map(item => {
+            return item === '상품금액' || item === '상품정보' ? (
+              <th scope="colgroup" colSpan={2} key={item}>
+                {item}
+              </th>
+            ) : (
+              <th scope="col" key={item}>
+                {item}
+              </th>
+            );
+          })}
+        </tr>
+      </thead>
+    </>
+  );
+}
+
+const headTrStyles = css({
+  th: {
+    height: '60px',
+    color: '#000',
+    textAlign: 'center',
+    fontSize: '18px',
+    fontWeight: '400',
+    lineHeight: '60px',
+    background: '#f2f2f2',
+    ':first-child': {
+      borderRadius: '10px 0 0 10px',
+    },
+    ':last-child': {
+      borderRadius: '0 10px 10px 0',
+    },
+  },
+});
+
+const allOrderSelectStyles = css({
+  cursor: 'pointer',
+  svg: {
+    verticalAlign: 'middle',
+  },
+});


### PR DESCRIPTION
## 변경 사항
- 장바구니 페이지, 주문/결제하기 페이지에서 사용할 상품 탭 메뉴 타이틀 컴포넌트 마크업
  - 컴포넌트 명: TabTitle.jsx
     - 전달받은 props로 총 3가지의 UI 표현 가능
   ![스크린샷 2023-08-05 오후 8 30 33](https://github.com/jsunbin/hodu/assets/96880673/2c62ffc2-0bbe-4ae3-9bf3-70bdb9bea8f3)
  ![스크린샷 2023-08-05 오후 8 30 53](https://github.com/jsunbin/hodu/assets/96880673/5500bdf5-3da0-4bf7-957b-b8680e1f8caf)
![스크린샷 2023-08-05 오후 8 31 06](https://github.com/jsunbin/hodu/assets/96880673/7f057da0-ce2e-4a61-abb6-30c47fc42d2c)



이슈번호: #37