### PR TITLE
🐛  Fix: 로그인 유지 안되는 이슈 해결 #67

### DIFF
--- a/src/recoil/TokenAtom.js
+++ b/src/recoil/TokenAtom.js
@@ -1,9 +1,16 @@
 import { atom, selector } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist({
+  key: 'token',
+  storage: localStorage,
+});
 
 // 토큰
 export const TokenAtom = atom({
   key: 'TokenAtom',
   default: undefined,
+  effects_UNSTABLE: [persistAtom],
 });
 
 // 로그인 여부를 확인하는 Selector


### PR DESCRIPTION
## 변경 사항
### 버그
- 로그인 후 페이지 이동할 때마다 로그인이 유지 안되고 풀리는 이슈
- 상태관리가 제대로 이루어 지지 않고 있는 듯 보임

### 해결방법
-  로그인 Atom에 recoilPersist를 사용하여 로컬 스토리지에 토큰 값을 저장하도록 함

### 해결 후
- 새로고침, 페이지 이동 후에도 로그인이 유지됨
  
![화면_기록_2023-08-22_오후_9_17_00_AdobeExpress](https://github.com/jsunbin/hodu/assets/96880673/5de2e6a3-78b8-4f77-b93e-9a41a2073a3a)

이슈번호: #67 