### PR TITLE
✨ Feat: 상품 상세 페이지 내 장바구니 기능 구현 #70

### DIFF
--- a/src/api/cartAPI.js
+++ b/src/api/cartAPI.js
@@ -1,0 +1,81 @@
+import axios from 'axios';
+
+// 장바구니 목록
+export const cartListAPI = async accessToken => {
+  try {
+    const response = await axios.get('https://openmarket.weniv.co.kr/cart/', {
+      headers: {
+        Authorization: `JWT ${accessToken}`,
+      },
+    });
+
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 장바구니 추가
+export const addCartAPI = async ({
+  accessToken,
+  productId,
+  amount,
+  isAvailable,
+}) => {
+  try {
+    console.log({
+      accessToken,
+      productId,
+      amount,
+      isAvailable,
+    });
+
+    console.log(productId);
+    const response = await axios.post(
+      'https://openmarket.weniv.co.kr/cart/',
+      {
+        product_id: productId,
+        quantity: amount,
+        check: isAvailable,
+      },
+      {
+        headers: {
+          Authorization: `JWT ${accessToken}`,
+        },
+      },
+    );
+
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 장바구니 수량 수정
+export const amountCartAPI = async ({
+  accessToken,
+  cartItemId,
+  productId,
+  quantity = 0,
+  isActive = false,
+}) => {
+  try {
+    const response = await axios.put(
+      `https://openmarket.weniv.co.kr/cart/${cartItemId}`,
+      {
+        product_id: productId,
+        quantity: quantity,
+        is_active: isActive,
+      },
+      {
+        headers: {
+          Authorization: `JWT ${accessToken}`,
+        },
+      },
+    );
+
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/pages/ProductDetailsPage/ProductDetailsPage.jsx
+++ b/src/pages/ProductDetailsPage/ProductDetailsPage.jsx
@@ -1,33 +1,68 @@
 /** @jsxImportSource @emotion/react */
 import React, { useState, useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { css } from '@emotion/react';
 import { productsDetailAPI } from '../../api/productsAPI';
+import { addCartAPI, cartListAPI } from '../../api/cartAPI';
 import { isUserSeller } from '../../recoil/LoginAtom';
 import { isLoginSelector, TokenAtom } from '../../recoil/TokenAtom';
 import { AmountAtom } from '../../recoil/AmountAtom';
+import {
+  closeModalSelector,
+  modalStateAtom,
+  openModalSelector,
+} from '../../recoil/ModalAtom';
 import Header from '../../components/common/Header/Header';
 import Footer from '../../components/common/Footer/Footer';
 import Price from '../../components/Price/Price';
 import Amount from '../../components/common/Amount/Amount';
 import Button from '../../components/Button/Button';
 import TabMenu from '../../components/TabMenu/TabMenu';
+import Modal from '../../components/Modal/Modal';
+import ConfirmModal from '../../components/Modal/ConfirmModal/ConfirmModal';
 
 export default function ProductDetailsPage() {
+  const navigate = useNavigate();
   const accessToken = useRecoilValue(TokenAtom);
   const isLogin = useRecoilValue(isLoginSelector);
   const isSeller = useRecoilValue(isUserSeller);
   const amount = useRecoilValue(AmountAtom);
+  const modalState = useRecoilValue(modalStateAtom);
+  const setOpenModal = useSetRecoilState(openModalSelector);
+  const setCloseModal = useSetRecoilState(closeModalSelector);
   const [item, setItem] = useState([]);
   const [price, setPrice] = useState('0');
   const [deliveryMethod, setDeliveryMethod] = useState('택배배송');
   const [deliveryFee, setDeliveryFee] = useState('무료배송');
+  const [isItemInCart, setIsItemInCart] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingError, setLoadingError] = useState(null);
+  const productId = window.location.pathname.replace('/product/', '');
 
-  const handleCartClick = () => {
-    console.log('장바구니 담기');
-    console.log('이동 확인 모달 띄우기');
+  const handleCartClick = async () => {
+    const data = await getCartList(accessToken);
+
+    const { results } = data.data;
+
+    console.log('results, ', results);
+    console.log(productId);
+
+    const isItemInResults = results.find(
+      item => item.product_id === Number(productId),
+    );
+
+    if (isItemInResults) {
+      setIsItemInCart(true);
+      setOpenModal();
+    } else {
+      await addItemToCart().then(setIsItemInCart(false)).then(setOpenModal());
+    }
+  };
+
+  const handleGoToCartClick = () => {
+    setCloseModal();
+    navigate('/cart');
   };
 
   const getProductsDetails = async productId => {
@@ -48,9 +83,40 @@ export default function ProductDetailsPage() {
     }
   };
 
-  useEffect(() => {
-    const productId = window.location.pathname.replace('/product/', '');
+  // 장바구니 목록 가져오기
+  const getCartList = async accessToken => {
+    try {
+      const data = await cartListAPI(accessToken);
 
+      console.log(data);
+      return data;
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  // 장바구니에 담기
+  const addItemToCart = async () => {
+    try {
+      setIsLoading(true);
+      setLoadingError(null);
+
+      const data = await addCartAPI({
+        accessToken,
+        productId,
+        amount,
+        isAvailable: true,
+      });
+
+      console.log(data);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
     getProductsDetails(productId);
   }, []);
 
@@ -66,6 +132,7 @@ export default function ProductDetailsPage() {
   return (
     <>
       <Header isLogin={isLogin} isSeller={isSeller} />
+
       {!isLoading ? (
         <main css={mainStyles}>
           <section css={firstWrapDivStyles}>
@@ -82,37 +149,61 @@ export default function ProductDetailsPage() {
               <span css={deliveryOptionsSpanStyles}>
                 {deliveryMethod} / {deliveryFee}
               </span>
-              <Amount max={3} />
-              <div css={productTotalStyles}>
-                <span className="title">총 상품 금액</span>
-                <div css={orderDetailsStyles}>
-                  <span css={orderAmountStyles} className="order-amount">
-                    총 수량 <strong>{amount}</strong>개
-                  </span>
-                  <Price size="lg" color="#21BF48">
-                    {price}
-                  </Price>
-                </div>
-              </div>
-              <div css={btnGroupsStyles}>
-                <Button size="md" width="416px" href={'/payment'}>
-                  바로구매
+
+              {item.stock === 0 ? (
+                <Button disabled width="630px">
+                  품절
                 </Button>
-                <Button
-                  size="md"
-                  color="dark"
-                  width="200px"
-                  onClickEvent={handleCartClick}
-                >
-                  장바구니
-                </Button>
-              </div>
+              ) : (
+                <>
+                  <Amount max={item.stock} />
+                  <div css={productTotalStyles}>
+                    <span className="title">총 상품 금액</span>
+                    <div css={orderDetailsStyles}>
+                      <span css={orderAmountStyles} className="order-amount">
+                        총 수량 <strong>{amount}</strong>개
+                      </span>
+                      <Price size="lg" color="#21BF48">
+                        {price}
+                      </Price>
+                    </div>
+                  </div>
+                  <div css={btnGroupsStyles}>
+                    <Button size="md" width="416px" href={'/payment'}>
+                      바로구매
+                    </Button>
+                    <Button
+                      size="md"
+                      color="dark"
+                      width="200px"
+                      onClickEvent={handleCartClick}
+                    >
+                      장바구니
+                    </Button>
+                  </div>
+                </>
+              )}
             </section>
           </section>
           <section css={productDetailsWrapStyles}>
             <TabMenu />
             <div className="menu-content"></div>
           </section>
+          {modalState.isOpen &&
+            (isItemInCart ? (
+              <Modal yesOnClickEvent={handleGoToCartClick}>
+                이미 장바구니에 있는 상품입니다.
+                <br />
+                장바구니로 이동하시겠습니까?
+              </Modal>
+            ) : (
+              <ConfirmModal
+                btnContent={'장바구니로 가기'}
+                btnClickEvent={handleGoToCartClick}
+              >
+                장바구니에 상품이 담겼습니다
+              </ConfirmModal>
+            ))}
         </main>
       ) : (
         <div>Loading...</div>
@@ -125,6 +216,7 @@ export default function ProductDetailsPage() {
 const mainStyles = css`
   width: 100%;
   margin: 80px auto;
+  position: relative;
 `;
 
 const firstWrapDivStyles = css({


### PR DESCRIPTION
## 변경 사항
- 상품 상세 페이지에서 장바구니 기능 구현
  - 이미 선택된 상품을 다시 선택하였을 때, 상품은 추가되지 않음
    - 장바구니로 가겠냐는 여부를 묻는 모달이 뜨고, 아니오를 클릭하면 현재 페이지에 남게 되고, 예를 클릭하면 장바구니 페이지로 이동하게 됨.
  - 장바구니 버튼을 눌렀을 시, ~~장바구니 페이지로 이동합니다.~~(상품 상세 페이지에서 선택한 제품은 장바구니에 추가됩니다.)
    - 장바구니에 추가가 되고, 추가되었다는 확인 모달이 나타남.
    - 장바구니로 가기 버튼을 클릭해야 장바구니로 이동하게 되고, 모달의 우측 상단에 위치한 x(닫기) 버튼을 클릭하면 모달이 닫히고, 현재 페이지에 남게 됨
 

- 장바구니에 상품이 없을 때
![화면_기록_2023-08-24_오전_12_27_45_AdobeExpress](https://github.com/jsunbin/hodu/assets/96880673/ce24fa42-dbc7-45db-b538-8c7a3420ccd7)

- 장바구니에 이미 상품이 담겨 있을 때
![화면_기록_2023-08-24_오전_12_26_33_AdobeExpress](https://github.com/jsunbin/hodu/assets/96880673/e9c4b4a7-e267-4d25-b483-ffc3cb350fc5)



이슈번호:  #65 , #70
