### PR TITLE
🐛  Fix: Amount 컴포넌트에서 플러스, 마이너스 버튼이 최대값에서 동시에 비활성화 되는 이슈 해결 #71

### DIFF
--- a/src/components/common/Amount/Amount.jsx
+++ b/src/components/common/Amount/Amount.jsx
@@ -25,6 +25,7 @@ export default function Amount({ max }) {
       setIsDisabeldPlus(false);
     } else if (amount >= max) {
       setIsDisabeldPlus(true);
+      setIsDisabeldMinus(false);
     } else if (amount > 1) {
       setIsDisabeldMinus(false);
     }


### PR DESCRIPTION
## 변경 사항
수량이 prop으로 전달받은 최대값이 되었을 때, 플러스(+) 버튼만 비활성화 되도록 수정

이슈번호:  #71
