### PR TITLE
✨ Feat: 장바구니 페이지 기능 구현 #75

### DIFF
--- a/src/api/cartAPI.js
+++ b/src/api/cartAPI.js
@@ -79,3 +79,21 @@ export const amountCartAPI = async (
     throw error;
   }
 };
+
+// 장바구니 상품 개별 삭제
+export const deleteCartItemAPI = async (accessToken, cartItemId) => {
+  try {
+    const response = await axios.delete(
+      `https://openmarket.weniv.co.kr/cart/${cartItemId}/`,
+      {
+        headers: {
+          Authorization: `JWT ${accessToken}`,
+        },
+      },
+    );
+
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/api/cartAPI.js
+++ b/src/api/cartAPI.js
@@ -52,20 +52,21 @@ export const addCartAPI = async ({
 };
 
 // 장바구니 수량 수정
-export const amountCartAPI = async ({
+export const amountCartAPI = async (
   accessToken,
   cartItemId,
   productId,
-  quantity = 0,
-  isActive = false,
-}) => {
+  quantity,
+  isActive = true,
+) => {
   try {
+    console.log(accessToken, cartItemId, productId, quantity, isActive);
     const response = await axios.put(
-      `https://openmarket.weniv.co.kr/cart/${cartItemId}`,
+      `https://openmarket.weniv.co.kr/cart/${cartItemId}/`,
       {
         product_id: productId,
         quantity: quantity,
-        is_active: isActive,
+        is_active: isActive, // 장바구니 내 상품 활성화 버튼, 같이 보내지 않으면 False
       },
       {
         headers: {
@@ -73,7 +74,6 @@ export const amountCartAPI = async ({
         },
       },
     );
-
     return response;
   } catch (error) {
     throw error;

--- a/src/components/OrderTotalBox/OrderTotalBox.jsx
+++ b/src/components/OrderTotalBox/OrderTotalBox.jsx
@@ -1,11 +1,38 @@
 /** @jsxImportSource @emotion/react */
-import React from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
 import Price from '../../components/Price/Price';
 import minusIcon from '../../assets/images/icon-minus-2.svg';
 import plusIcon from '../../assets/images/icon-plus-2.svg';
+import { useRecoilState } from 'recoil';
+import { CartItemAtom } from '../../recoil/CartItemAtom';
+import { useEffect } from 'react';
 
-export default function OrderTotalBox() {
+export default function OrderTotalBox({ checkList, isAmountChanged }) {
+  const [totalProductPrice, setTotalProductPrice] = useState(0);
+  const [totalShippingFee, setTotalShippingFee] = useState(0);
+  const [totalPrice, setTotalPrice] = useState(0);
+
+  console.log('total: ', checkList);
+
+  useEffect(() => {
+    console.log(checkList);
+    setTotalProductPrice(
+      checkList
+        .filter(item => item.isChecked)
+        .reduce((total, item) => total + item.price, 0),
+    );
+    setTotalShippingFee(
+      checkList
+        .filter(item => item.isChecked)
+        .reduce((total, item) => total + item.deliveryFee, 0),
+    );
+  }, [isAmountChanged, checkList]);
+
+  useEffect(() => {
+    setTotalPrice(totalProductPrice + totalShippingFee);
+  }, [totalProductPrice, totalShippingFee]);
+
   return (
     <div css={orderTotalBoxWrapDivStyles}>
       <div
@@ -20,7 +47,7 @@ export default function OrderTotalBox() {
         ]}
       >
         <h4>총 상품금액</h4>
-        <Price size="md">46,500</Price>
+        <Price size="md">{totalProductPrice}</Price>
       </div>
 
       <div
@@ -40,13 +67,13 @@ export default function OrderTotalBox() {
 
       <div css={itemStyles}>
         <h4>배송비</h4>
-        <Price size="md">0</Price>
+        <Price size="md">{totalShippingFee}</Price>
       </div>
 
       <div css={itemStyles}>
         <h4>결제 예정 금액</h4>
         <Price size="lg" color="#EB5757">
-          46,500
+          {totalPrice}
         </Price>
       </div>
     </div>

--- a/src/components/Product/ProductTable/ProductTable.jsx
+++ b/src/components/Product/ProductTable/ProductTable.jsx
@@ -8,14 +8,24 @@ export default function ProductTable({
   page = 'cart',
   isCheckBox = true,
   items,
+  checkList,
+  setCheckList,
+  isAmountChanged,
+  setIsAmountChanged,
 }) {
-  const [checkList, setCheckList] = useState([]);
+  // const [checkList, setCheckList] = useState([]);
 
-  console.log(items);
+  console.log('장바구니 리스트: ', items);
+  console.log('체크리스트: ', checkList);
 
   useEffect(() => {
     setCheckList(
-      items.map(item => ({ id: item.product_id, isChecked: false })),
+      items.map(item => ({
+        id: item.product_id,
+        isChecked: false,
+        price: 0 * item.quantity,
+        deliveryFee: 0,
+      })),
     );
   }, []);
 
@@ -32,6 +42,8 @@ export default function ProductTable({
           items={items}
           checkList={checkList}
           setCheckList={setCheckList}
+          isAmountChanged={isAmountChanged}
+          setIsAmountChanged={setIsAmountChanged}
         />
       ) : (
         <tbody>

--- a/src/components/Product/ProductTable/ProductTable.jsx
+++ b/src/components/Product/ProductTable/ProductTable.jsx
@@ -1,25 +1,35 @@
 /** @jsxImportSource @emotion/react */
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 import ProductTableTitle from './ProductTableTitle';
-import ProductTableItemCart from './ProductTableItemCart';
-import ProductTableItemPayment from './ProductTableItemPayment';
+import ProductTableTbody from './ProductTableTbody';
 
-export default function ProductTable({ page = 'cart', isCheckBox = true }) {
+export default function ProductTable({
+  page = 'cart',
+  isCheckBox = true,
+  items,
+}) {
+  const [checkList, setCheckList] = useState([]);
+
+  useEffect(() => {
+    setCheckList(
+      items.map(item => ({ id: item.product_id, isChecked: false })),
+    );
+  }, []);
+
   return (
     <table css={tableStyles({ page })} className={`${page}-table`}>
-      <ProductTableTitle page={page} isCheckBox={isCheckBox} />
-      <tbody css={tbodyStyles({ page })}>
-        <tr css={trStyles({ page })}>
-          {page === 'cart' ? (
-            <td colSpan={5}>
-              <ProductTableItemCart />
-            </td>
-          ) : (
-            <ProductTableItemPayment />
-          )}
-        </tr>
-      </tbody>
+      <ProductTableTitle
+        page={page}
+        isCheckBox={isCheckBox}
+        checkList={checkList}
+        setCheckList={setCheckList}
+      />
+      <ProductTableTbody
+        items={items}
+        checkList={checkList}
+        setCheckList={setCheckList}
+      />
     </table>
   );
 }
@@ -29,30 +39,4 @@ const tableStyles = props => css`
   text-align: center;
   border-collapse: separate;
   border-spacing: ${props.page === 'cart' ? '0 35px' : '0 16px'};
-`;
-
-const tbodyStyles = props => css`
-  border-collapse: separate;
-  border-spacing: ${props.page === 'cart' ? '0 10px' : '0 16px'};
-  td {
-    vertical-align: middle;
-  }
-`;
-
-const trStyles = props => css`
-  position: relative;
-
-  ${props.page === 'order' &&
-  css`
-    ::after {
-      content: '';
-      display: block;
-      width: 100%;
-      height: 1px;
-      background: #c4c4c4;
-      position: absolute;
-      bottom: 0;
-      left: 0;
-    }
-  `}
 `;

--- a/src/components/Product/ProductTable/ProductTable.jsx
+++ b/src/components/Product/ProductTable/ProductTable.jsx
@@ -11,6 +11,8 @@ export default function ProductTable({
 }) {
   const [checkList, setCheckList] = useState([]);
 
+  console.log(items);
+
   useEffect(() => {
     setCheckList(
       items.map(item => ({ id: item.product_id, isChecked: false })),
@@ -25,14 +27,57 @@ export default function ProductTable({
         checkList={checkList}
         setCheckList={setCheckList}
       />
-      <ProductTableTbody
-        items={items}
-        checkList={checkList}
-        setCheckList={setCheckList}
-      />
+      {items.length !== 0 ? (
+        <ProductTableTbody
+          items={items}
+          checkList={checkList}
+          setCheckList={setCheckList}
+        />
+      ) : (
+        <tbody>
+          <tr>
+            <td colSpan={5}>
+              <div css={noItemDivStyles}>
+                <strong css={strongStyles}>
+                  장바구니에 담긴 상품이 없습니다.
+                </strong>
+                <span css={noItemSpanStyles}>
+                  원하는 상품을 장바구니에 담아보세요!
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      )}
     </table>
   );
 }
+
+const noItemDivStyles = css`
+  width: 100%;
+  height: 50vh;
+`;
+
+const strongStyles = css`
+  display: block;
+  color: #000;
+  font-family: Spoqa Han Sans Neo;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+`;
+
+const noItemSpanStyles = css`
+  display: block;
+  color: var(--767676, #767676);
+  font-family: Spoqa Han Sans Neo;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  margin-top: 16px;
+`;
 
 const tableStyles = props => css`
   width: 1280px;

--- a/src/components/Product/ProductTable/ProductTableItemCart.jsx
+++ b/src/components/Product/ProductTable/ProductTableItemCart.jsx
@@ -30,6 +30,12 @@ export default function ProductTableItemCart({
     event.preventDefault();
 
     setIsChecked(!isChecked);
+
+    setCheckList(prevList =>
+      prevList.map(item =>
+        item.id === productId ? { ...item, isChecked: !item.isChecked } : item,
+      ),
+    );
   };
 
   // 상품 상세 정보

--- a/src/components/Product/ProductTable/ProductTableItemCart.jsx
+++ b/src/components/Product/ProductTable/ProductTableItemCart.jsx
@@ -1,8 +1,11 @@
 /** @jsxImportSource @emotion/react */
 import React, { useState, useEffect } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { TokenAtom } from '../../../recoil/TokenAtom';
 import { AmountAtom } from '../../../recoil/AmountAtom';
 import { AllCheckedAtom } from '../../../recoil/AllCheckedAtom';
+import { openModalSelector } from '../../../recoil/ModalAtom';
+import { cartItemToDeleteAtom } from '../../../recoil/CartItemToDeleteAtom';
 import { productsDetailAPI } from '../../../api/productsAPI';
 import { css } from '@emotion/react';
 import Amount from '../../common/Amount/Amount';
@@ -10,7 +13,6 @@ import Button from '../../Button/Button';
 import DeliveryMethod from '../../DeliveryMethod/DeliveryMethod';
 import { Link } from 'react-router-dom';
 import { amountCartAPI } from '../../../api/cartAPI';
-import { TokenAtom } from '../../../recoil/TokenAtom';
 import NoButtonModal from '../../Modal/NoButtonMoal/NoButtonModal';
 
 export default function ProductTableItemCart({
@@ -29,6 +31,16 @@ export default function ProductTableItemCart({
 
   const [isDifferent, setIsDifferent] = useState(false);
   const [isChanged, setIsChanged] = useState(false);
+
+  const setOpenModal = useSetRecoilState(openModalSelector);
+  const setCartItemToDelete = useSetRecoilState(cartItemToDeleteAtom);
+
+  // 장바구니 삭제 클릭
+  const handleDeleteClick = (event, cartItemId) => {
+    event.preventDefault();
+    setOpenModal();
+    setCartItemToDelete(cartItemId);
+  };
 
   useEffect(() => {
     setIsChecked(isAllCheckedR);
@@ -95,7 +107,11 @@ export default function ProductTableItemCart({
 
   return (
     !isLoading && (
-      <article css={productItemArticleStyles} data-id={item.product_id}>
+      <article
+        css={productItemArticleStyles}
+        data-id={item.product_id}
+        data-cart-item-id={item.product_item_id}
+      >
         <div css={css({ margin: '0 30px' })}>
           <label>
             <input
@@ -219,7 +235,10 @@ export default function ProductTableItemCart({
         </div>
 
         <div css={itemDeleteStyles}>
-          <button type="button">
+          <button
+            type="button"
+            onClick={event => handleDeleteClick(event, item.cart_item_id)}
+          >
             <svg
               width="22"
               height="22"

--- a/src/components/Product/ProductTable/ProductTableItemCart.jsx
+++ b/src/components/Product/ProductTable/ProductTableItemCart.jsx
@@ -19,6 +19,8 @@ export default function ProductTableItemCart({
   item,
   checkList,
   setCheckList,
+  isAmountChanged,
+  setIsAmountChanged,
 }) {
   const accessToken = useRecoilValue(TokenAtom);
   const isAllCheckedR = useRecoilValue(AllCheckedAtom);
@@ -29,7 +31,7 @@ export default function ProductTableItemCart({
   const [amount, setAmount] = useRecoilState(AmountAtom);
 
   const [isDifferent, setIsDifferent] = useState(false);
-  const [isChanged, setIsChanged] = useState(false);
+  // const [isAmountChanged, setIsAmountChanged] = useState(false);
 
   const setOpenModal = useSetRecoilState(openModalSelector);
   const setCartItemToDelete = useSetRecoilState(cartItemToDeleteAtom);
@@ -78,7 +80,7 @@ export default function ProductTableItemCart({
         amount,
       );
 
-      setIsChanged(false);
+      setIsAmountChanged(false);
 
       // 주문수정 후, 1.5초 뒤에 NoButtomModal 닫기
       setIsNoButtonModalVisible(true);
@@ -111,6 +113,23 @@ export default function ProductTableItemCart({
   useEffect(() => {
     getProductsDetails();
   }, []);
+
+  useEffect(() => {
+    console.log('checked됨');
+    // setCheckList(updatedCheckList);
+
+    setCheckList(prevList =>
+      prevList.map(v =>
+        v.id === item.product_id
+          ? {
+              ...v,
+              price: productTotalPrice(),
+              deliveryFee: product.shipping_fee,
+            }
+          : v,
+      ),
+    );
+  }, [isChecked]);
 
   return (
     !isLoading && (
@@ -184,7 +203,7 @@ export default function ProductTableItemCart({
                 min={item.quantity}
                 max={product.stock}
                 setIsDifferent={setIsDifferent}
-                setIsChanged={setIsChanged}
+                setIsAmountChanged={setIsAmountChanged}
                 setAmountG={setAmountG}
               />
               {isDifferent && (
@@ -204,7 +223,7 @@ export default function ProductTableItemCart({
                   </strong>
                 </>
               )}
-              {isChanged && (
+              {isAmountChanged && (
                 <button
                   type="button"
                   onClick={handleOrderChangeClick}

--- a/src/components/Product/ProductTable/ProductTableItemCart.jsx
+++ b/src/components/Product/ProductTable/ProductTableItemCart.jsx
@@ -20,7 +20,6 @@ export default function ProductTableItemCart({
   checkList,
   setCheckList,
 }) {
-  console.log(item);
   const accessToken = useRecoilValue(TokenAtom);
   const isAllCheckedR = useRecoilValue(AllCheckedAtom);
   const [product, setProduct] = useState([]);
@@ -34,6 +33,14 @@ export default function ProductTableItemCart({
 
   const setOpenModal = useSetRecoilState(openModalSelector);
   const setCartItemToDelete = useSetRecoilState(cartItemToDeleteAtom);
+
+  const [amountG, setAmountG] = useState(0);
+
+  const productTotalPrice = () => {
+    const { price } = product;
+
+    return price * amountG;
+  };
 
   // 장바구니 삭제 클릭
   const handleDeleteClick = (event, cartItemId) => {
@@ -154,7 +161,9 @@ export default function ProductTableItemCart({
             <Link to={`/product/${item.product_id}`}>
               <strong className="product-name">{product.product_name}</strong>
             </Link>
-            <span className="product-unit-price">{product.price}원</span>
+            <span className="product-unit-price">
+              {parseInt(product.price).toLocaleString()}원
+            </span>
             {/* <span css={deliveryOptionsSpanStyles}>택배배송 / 무료배송</span> */}
             <DeliveryMethod
               styles={deliveryOptionsSpanStyles}
@@ -176,6 +185,7 @@ export default function ProductTableItemCart({
                 max={product.stock}
                 setIsDifferent={setIsDifferent}
                 setIsChanged={setIsChanged}
+                setAmountG={setAmountG}
               />
               {isDifferent && (
                 <>
@@ -227,8 +237,8 @@ export default function ProductTableItemCart({
           )}
         </div>
 
-        <div css={productTotalPrice}>
-          <span>17,500원</span>
+        <div css={productTotalPriceStyles}>
+          <span>{productTotalPrice().toLocaleString()}원</span>
           <Button size="sm" width="130px">
             주문하기
           </Button>
@@ -328,7 +338,7 @@ const deliveryOptionsSpanStyles = css({
   marginTop: '40px',
 });
 
-const productTotalPrice = css({
+const productTotalPriceStyles = css({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',

--- a/src/components/Product/ProductTable/ProductTableTbody.jsx
+++ b/src/components/Product/ProductTable/ProductTableTbody.jsx
@@ -1,0 +1,60 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import { css } from '@emotion/react';
+import ProductTableItemCart from './ProductTableItemCart';
+import ProductTableItemPayment from './ProductTableItemPayment';
+
+export default function ProductTableTbody({
+  page = 'cart',
+  items,
+  checkList,
+  setCheckList,
+}) {
+  return page === 'cart' ? (
+    <tbody css={tbodyStyles({ page })}>
+      {items.map(item => (
+        <tr css={trStyles({ page })} key={item.product_id}>
+          <td colSpan={5}>
+            <ProductTableItemCart
+              item={item}
+              checkList={checkList}
+              setCheckList={setCheckList}
+            />
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  ) : (
+    <tbody css={tbodyStyles({ page })}>
+      <tr css={trStyles({ page })}>
+        <ProductTableItemPayment />
+      </tr>
+    </tbody>
+  );
+}
+
+const tbodyStyles = props => css`
+  border-collapse: separate;
+  border-spacing: ${props.page === 'cart' ? '0 10px' : '0 16px'};
+  td {
+    vertical-align: middle;
+  }
+`;
+
+const trStyles = props => css`
+  position: relative;
+
+  ${props.page === 'order' &&
+  css`
+    ::after {
+      content: '';
+      display: block;
+      width: 100%;
+      height: 1px;
+      background: #c4c4c4;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+    }
+  `}
+`;

--- a/src/components/Product/ProductTable/ProductTableTbody.jsx
+++ b/src/components/Product/ProductTable/ProductTableTbody.jsx
@@ -9,6 +9,8 @@ export default function ProductTableTbody({
   items,
   checkList,
   setCheckList,
+  isAmountChanged,
+  setIsAmountChanged,
 }) {
   return page === 'cart' ? (
     <tbody css={tbodyStyles({ page })}>
@@ -19,6 +21,8 @@ export default function ProductTableTbody({
               item={item}
               checkList={checkList}
               setCheckList={setCheckList}
+              isAmountChanged={isAmountChanged}
+              setIsAmountChanged={setIsAmountChanged}
             />
           </td>
         </tr>

--- a/src/components/Product/ProductTable/ProductTableTitle.jsx
+++ b/src/components/Product/ProductTable/ProductTableTitle.jsx
@@ -27,8 +27,12 @@ export default function ProductTableTitle({
   };
 
   useEffect(() => {
-    const isAllChecked = checkList.every(item => item.isChecked);
-    setIsChecked(isAllChecked);
+    if (checkList.length !== 0) {
+      const isAllChecked = checkList.every(item => item.isChecked);
+      setIsChecked(isAllChecked);
+    } else {
+      setIsChecked(false);
+    }
   }, [checkList]);
 
   const tabTitleList = {

--- a/src/components/Product/ProductTable/ProductTableTitle.jsx
+++ b/src/components/Product/ProductTable/ProductTableTitle.jsx
@@ -1,17 +1,35 @@
 /** @jsxImportSource @emotion/react */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { AllCheckedAtom } from '../../../recoil/AllCheckedAtom';
 import { css } from '@emotion/react';
 
 export default function ProductTableTitle({
   page = 'cart',
   isCheckBox = true,
+  checkList,
+  setCheckList,
 }) {
   const [isChecked, setIsChecked] = useState(false);
+  const setIsAllCheckedR = useSetRecoilState(AllCheckedAtom);
 
   const handleCheckBoxClick = event => {
     event.preventDefault();
     setIsChecked(!isChecked);
+    setIsAllCheckedR(!isChecked);
+
+    const updatedCheckList = checkList.map(item => ({
+      ...item,
+      isChecked: !isChecked,
+    }));
+
+    setCheckList(updatedCheckList);
   };
+
+  useEffect(() => {
+    const isAllChecked = checkList.every(item => item.isChecked);
+    setIsChecked(isAllChecked);
+  }, [checkList]);
 
   const tabTitleList = {
     cart: {

--- a/src/components/common/Amount/Amount.jsx
+++ b/src/components/common/Amount/Amount.jsx
@@ -1,35 +1,56 @@
 /** @jsxImportSource @emotion/react */
 import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { AmountAtom } from '../../../recoil/AmountAtom';
 
-export default function Amount({ max }) {
-  // const [amount, setAmount] = useState(1);
-  const [isDisabledMinus, setIsDisabeldMinus] = useState(true);
+export default function Amount({
+  min = 1,
+  max,
+  setIsDifferent = () => {},
+  setIsChanged = () => {},
+}) {
+  const [amount, setAmount] = useState(min);
+  const setAmountAtom = useSetRecoilState(AmountAtom);
+  const [isDisabledMinus, setIsDisabeldMinus] = useState(false);
   const [isDisabledPlus, setIsDisabeldPlus] = useState(false);
-  const [amount, setAmount] = useRecoilState(AmountAtom);
 
   const minusClickHandler = () => {
     setAmount(prev => prev - 1);
+    setIsChanged(true);
   };
 
   const plusClickHandelr = () => {
     setAmount(prev => prev + 1);
+    setIsChanged(true);
+  };
+
+  const setAmountAction = () => {
+    if (amount <= 1) {
+      setIsDisabeldMinus(true);
+      setIsDisabeldPlus(false);
+      setIsDifferent(false);
+    } else if (amount < max) {
+      setIsDisabeldMinus(false);
+      setIsDisabeldPlus(false);
+      setIsDifferent(false);
+    } else if (amount >= max) {
+      setIsDisabeldMinus(false);
+      setIsDisabeldPlus(true);
+    }
   };
 
   useEffect(() => {
-    console.log(amount);
-    if (amount === 1) {
-      setIsDisabeldMinus(true);
-      setIsDisabeldPlus(false);
-    } else if (amount >= max) {
-      setIsDisabeldPlus(true);
-      setIsDisabeldMinus(false);
-    } else if (amount > 1) {
-      setIsDisabeldMinus(false);
-    }
+    setAmountAction();
+    setAmountAtom(amount);
   }, [amount]);
+
+  useEffect(() => {
+    if (min > max) {
+      setIsDifferent(true);
+      setAmount(max);
+    }
+  }, []);
 
   return (
     <div css={amountDivStyles}>

--- a/src/components/common/Amount/Amount.jsx
+++ b/src/components/common/Amount/Amount.jsx
@@ -9,6 +9,7 @@ export default function Amount({
   max,
   setIsDifferent = () => {},
   setIsChanged = () => {},
+  setAmountG = () => {},
 }) {
   const [amount, setAmount] = useState(min);
   const setAmountAtom = useSetRecoilState(AmountAtom);
@@ -43,6 +44,7 @@ export default function Amount({
   useEffect(() => {
     setAmountAction();
     setAmountAtom(amount);
+    setAmountG(amount);
   }, [amount]);
 
   useEffect(() => {

--- a/src/pages/CartPage/CartPage.jsx
+++ b/src/pages/CartPage/CartPage.jsx
@@ -71,11 +71,19 @@ export default function CartPage() {
         <main>
           <div css={contentDivStyles}>
             <h2 css={h2Styles}>장바구니</h2>
+
             <ProductTable items={items} />
-            <OrderTotalBox />
-            <div css={buttonWrapDivStyles}>
-              <Button size="lg">주문하기</Button>
-            </div>
+
+            {items.length !== 0 ? (
+              <>
+                <OrderTotalBox />
+                <div css={buttonWrapDivStyles}>
+                  <Button size="lg">주문하기</Button>
+                </div>
+              </>
+            ) : (
+              ''
+            )}
           </div>
           {modalState.isOpen && (
             <Modal yesOnClickEvent={handleDeleteClick}>

--- a/src/pages/CartPage/CartPage.jsx
+++ b/src/pages/CartPage/CartPage.jsx
@@ -1,14 +1,21 @@
 /** @jsxImportSource @emotion/react */
 import React, { useState, useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { isLoginSelector, TokenAtom } from '../../recoil/TokenAtom';
 import { isUserSeller } from '../../recoil/LoginAtom';
-import { cartListAPI } from '../../api/cartAPI';
+import { cartItemToDeleteAtom } from '../../recoil/CartItemToDeleteAtom';
+import {
+  closeModalSelector,
+  modalStateAtom,
+  openModalSelector,
+} from '../../recoil/ModalAtom';
+import { cartListAPI, deleteCartItemAPI } from '../../api/cartAPI';
 import { css } from '@emotion/react';
 import Header from '../../components/common/Header/Header';
 import ProductTable from '../../components/Product/ProductTable/ProductTable';
 import OrderTotalBox from '../../components/OrderTotalBox/OrderTotalBox';
 import Button from '../../components/Button/Button';
+import Modal from '../../components/Modal/Modal';
 import Footer from '../../components/common/Footer/Footer';
 
 export default function CartPage() {
@@ -18,6 +25,25 @@ export default function CartPage() {
   const [items, setItems] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingError, setLoadingError] = useState(null);
+  const modalState = useRecoilValue(modalStateAtom);
+  const setOpenModal = useSetRecoilState(openModalSelector);
+  const setCloseModal = useSetRecoilState(closeModalSelector);
+  const cartItemIdToDelete = useRecoilValue(cartItemToDeleteAtom);
+
+  const handleDeleteClick = () => {
+    setCloseModal();
+    deleteCartItem();
+
+    setItems(prev => prev.filter(v => v.cart_item_id !== cartItemIdToDelete));
+  };
+
+  const deleteCartItem = async () => {
+    try {
+      const data = await deleteCartItemAPI(accessToken, cartItemIdToDelete);
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   const getCartList = async () => {
     try {
@@ -51,6 +77,11 @@ export default function CartPage() {
               <Button size="lg">주문하기</Button>
             </div>
           </div>
+          {modalState.isOpen && (
+            <Modal yesOnClickEvent={handleDeleteClick}>
+              상품을 삭제하시겠습니까?
+            </Modal>
+          )}
         </main>
       ) : (
         <div>Loading...</div>

--- a/src/pages/CartPage/CartPage.jsx
+++ b/src/pages/CartPage/CartPage.jsx
@@ -1,5 +1,9 @@
 /** @jsxImportSource @emotion/react */
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { isLoginSelector, TokenAtom } from '../../recoil/TokenAtom';
+import { isUserSeller } from '../../recoil/LoginAtom';
+import { cartListAPI } from '../../api/cartAPI';
 import { css } from '@emotion/react';
 import Header from '../../components/common/Header/Header';
 import ProductTable from '../../components/Product/ProductTable/ProductTable';
@@ -8,19 +12,50 @@ import Button from '../../components/Button/Button';
 import Footer from '../../components/common/Footer/Footer';
 
 export default function CartPage() {
+  const accessToken = useRecoilValue(TokenAtom);
+  const isLogin = useRecoilValue(isLoginSelector);
+  const isSeller = useRecoilValue(isUserSeller);
+  const [items, setItems] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadingError, setLoadingError] = useState(null);
+
+  const getCartList = async () => {
+    try {
+      setIsLoading(true);
+      setLoadingError(null);
+      const data = await cartListAPI(accessToken);
+      const { results } = data.data;
+      setItems(results);
+    } catch (error) {
+      setLoadingError(error);
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    getCartList();
+  }, []);
+
   return (
     <>
-      <Header />
-      <main>
-        <div css={contentDivStyles}>
-          <h2 css={h2Styles}>장바구니</h2>
-          <ProductTable />
-          <OrderTotalBox />
-          <div css={buttonWrapDivStyles}>
-            <Button size="lg">주문하기</Button>
+      <Header isLogin={isLogin} isSeller={isSeller} />
+      {!isLoading ? (
+        <main>
+          <div css={contentDivStyles}>
+            <h2 css={h2Styles}>장바구니</h2>
+            <ProductTable items={items} />
+            <OrderTotalBox />
+            <div css={buttonWrapDivStyles}>
+              <Button size="lg">주문하기</Button>
+            </div>
           </div>
-        </div>
-      </main>
+        </main>
+      ) : (
+        <div>Loading...</div>
+      )}
+
       <Footer />
     </>
   );

--- a/src/pages/CartPage/CartPage.jsx
+++ b/src/pages/CartPage/CartPage.jsx
@@ -29,6 +29,7 @@ export default function CartPage() {
   const setOpenModal = useSetRecoilState(openModalSelector);
   const setCloseModal = useSetRecoilState(closeModalSelector);
   const cartItemIdToDelete = useRecoilValue(cartItemToDeleteAtom);
+  const [isAmountChanged, setIsAmountChanged] = useState(false);
 
   const handleDeleteClick = () => {
     setCloseModal();
@@ -64,6 +65,8 @@ export default function CartPage() {
     getCartList();
   }, []);
 
+  const [checkList, setCheckList] = useState([]);
+
   return (
     <>
       <Header isLogin={isLogin} isSeller={isSeller} />
@@ -72,11 +75,20 @@ export default function CartPage() {
           <div css={contentDivStyles}>
             <h2 css={h2Styles}>장바구니</h2>
 
-            <ProductTable items={items} />
+            <ProductTable
+              items={items}
+              checkList={checkList}
+              setCheckList={setCheckList}
+              isAmountChanged={isAmountChanged}
+              setIsAmountChanged={setIsAmountChanged}
+            />
 
             {items.length !== 0 ? (
               <>
-                <OrderTotalBox />
+                <OrderTotalBox
+                  checkList={checkList}
+                  isAmountChanged={isAmountChanged}
+                />
                 <div css={buttonWrapDivStyles}>
                   <Button size="lg">주문하기</Button>
                 </div>

--- a/src/recoil/AllCheckedAtom.js
+++ b/src/recoil/AllCheckedAtom.js
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+
+// 전체 선택
+export const AllCheckedAtom = atom({
+  key: 'AllCheckedAtom',
+  default: false,
+});

--- a/src/recoil/CartItemToDeleteAtom.js
+++ b/src/recoil/CartItemToDeleteAtom.js
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const cartItemToDeleteAtom = atom({
+  key: 'cartItemToDeleteAtom',
+  default: undefined,
+});


### PR DESCRIPTION
## 변경 사항
### 장바구니 페이지
- 장바구니에서 상품의 수량을 수정할 때, `+`나 `-` 버튼을 누르면 `주문수정` 버튼이 나타납니다. 이 버튼을 클릭해야 주문수정이 완료 됩니다.
- 상품이 재고 수량을 초과하면 `+`버튼은 비활성화 됩니다.
- 선택된 정보만 총 상품금액과 할인, 배송비가 적용되어 총 결제할 가격이 나타나야 합니다.
- 상품의 `x` 버튼을 클릭할 시 상품 삭제를 재확인하는 모달 창이 중앙에 나타나야 합니다.
- 상품 삭제를 재확인하는 모달의 확인 버튼을 클릭하면 상품이 삭제되어야 합니다.


이슈번호:  #75 
