### PR TITLE
✨ Feat: 회원가입 기능 구현 (구매회원) #55

### DIFF
--- a/src/api/signupAPI.js
+++ b/src/api/signupAPI.js
@@ -1,0 +1,29 @@
+import axios from 'axios';
+
+// 계정 검증
+export const accountsValid = async userId => {
+  try {
+    const response = await axios.post(
+      'https://openmarket.weniv.co.kr/accounts/signup/valid/username/',
+      { username: userId },
+    );
+
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 가입
+export const signup = async requestBody => {
+  try {
+    const response = await axios.post(
+      'https://openmarket.weniv.co.kr/accounts/signup/',
+      requestBody,
+    );
+
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/components/JoinForm/JoinForm.jsx
+++ b/src/components/JoinForm/JoinForm.jsx
@@ -6,6 +6,7 @@ import NumDropDown from '../NumDropDown/NumDropDown';
 import CheckText from '../CheckText/CheckText';
 
 export default function JoinForm({ isSeller }) {
+  const [firstPhoneNum, setFirstPhoneNum] = useState('010');
   const [isClicked, setIsClicked] = useState(false);
 
   const phoneNumClickHandler = () => {
@@ -80,10 +81,57 @@ export default function JoinForm({ isSeller }) {
                   aria-controls="phoneStart"
                   aria-expanded={false}
                   onClick={phoneNumClickHandler}
+                  css={css`
+                    position: relative;
+                  `}
                 >
-                  010
+                  <span>{firstPhoneNum}</span>
+                  <span
+                    css={css`
+                      position: absolute;
+                      top: 16px;
+                      right: 14px;
+                    `}
+                  >
+                    {!isClicked ? (
+                      <svg
+                        width="22"
+                        height="22"
+                        viewBox="0 0 22 22"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M17.4163 8.25005L10.9997 13.6583L4.58301 8.25005"
+                          stroke="#767676"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    ) : (
+                      <svg
+                        width="22"
+                        height="22"
+                        viewBox="0 0 22 22"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M4.58366 13.6583L11.0003 8.25006L17.417 13.6583"
+                          stroke="#767676"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    )}
+                  </span>
                 </button>
-                {isClicked && <NumDropDown />}
+                {isClicked && (
+                  <NumDropDown
+                    onClick={setFirstPhoneNum}
+                    setIsClicked={setIsClicked}
+                  />
+                )}
                 <input
                   type="tel"
                   id="phoneNo"

--- a/src/components/JoinForm/JoinForm.jsx
+++ b/src/components/JoinForm/JoinForm.jsx
@@ -49,6 +49,13 @@ export default function JoinForm({ isSeller }) {
     handleChange(name, value);
   };
 
+  const checkUserName = () => {
+    // 아이디를 입력하지 않고 비밀번호를 입력한 경우
+    if (values.username === '') {
+      setUserNameMessage({ message: '필수 정보입니다.', color: '#EB5757' });
+    }
+  };
+
   const checkPassword = event => {
     // 비밀번호 유효성 검사: 포커스 아웃 될 때 실행됨.
     const currentInputPassword1 = event.target.value;
@@ -86,11 +93,6 @@ export default function JoinForm({ isSeller }) {
         color: 'default',
         isValid: true,
       });
-    }
-
-    // 아이디를 입력하지 않고 비밀번호를 입력한 경우
-    if (values.username === '') {
-      setUserNameMessage({ message: '필수 정보입니다.', color: '#EB5757' });
     }
   };
 
@@ -141,9 +143,15 @@ export default function JoinForm({ isSeller }) {
   };
   const idValidClickHandler = event => {
     console.log('이메일 계정 검증');
+    var RegExp = /^[a-zA-Z0-9]{4,20}$/;
 
     if (values.username === '') {
       setUserNameMessage({ message: '필수 정보입니다.', color: '#EB5757' });
+    } else if (!RegExp.test(values.username)) {
+      setUserNameMessage({
+        message: '4 ~ 20자 이내의 영문 소문자, 대문자 숫자만 사용 가능합니다.',
+        color: '#EB5757',
+      });
     } else {
       userIdValid();
     }
@@ -198,6 +206,7 @@ export default function JoinForm({ isSeller }) {
                 name="password"
                 maxLength={20}
                 autoComplete="new-password"
+                onClick={checkUserName}
                 onChange={handleInputChange}
                 onBlur={checkPassword}
               />

--- a/src/components/JoinForm/JoinForm.jsx
+++ b/src/components/JoinForm/JoinForm.jsx
@@ -4,13 +4,56 @@ import { css } from '@emotion/react';
 import Button from '../Button/Button';
 import NumDropDown from '../NumDropDown/NumDropDown';
 import CheckText from '../CheckText/CheckText';
+import { accountsValid } from '../../api/signupAPI';
+import { useRecoilValue } from 'recoil';
+
+const INITIAL_VALUES = {
+  username: '',
+  password: '',
+  password2: '',
+  phone_number: '',
+  name: '',
+};
 
 export default function JoinForm({ isSeller }) {
+  const [values, setValues] = useState(INITIAL_VALUES);
   const [firstPhoneNum, setFirstPhoneNum] = useState('010');
   const [isClicked, setIsClicked] = useState(false);
+  const [userNameMessage, setUserNameMessage] = useState({
+    message: null,
+    color: 'default',
+  });
+  const [passwordError, setPasswordError] = useState(null);
 
   const phoneNumClickHandler = () => {
     setIsClicked(!isClicked);
+  };
+
+  const handleChange = (name, value) => {
+    setValues(prevValues => ({ ...prevValues, [name]: value }));
+    console.log(values);
+  };
+
+  const handleInputChange = event => {
+    const { name, value } = event.target;
+    handleChange(name, value);
+  };
+
+  const idValidClickHandler = event => {
+    console.log('이메일 계정 검증');
+    userIdValid();
+  };
+
+  const userIdValid = async () => {
+    try {
+      const response = await accountsValid(values.username);
+      console.log(response);
+      setUserNameMessage({ message: response.Success, color: 'default' });
+    } catch (e) {
+      // console.error(e);
+      const failMessage = e.response?.data?.FAIL_Message;
+      setUserNameMessage({ message: failMessage, color: '#EB5757' });
+    }
   };
 
   return (
@@ -26,15 +69,22 @@ export default function JoinForm({ isSeller }) {
                 <label htmlFor="id">아이디</label>
                 <input
                   type="text"
-                  id="id"
-                  name="id"
-                  className="id"
+                  id="userName"
+                  name="username"
                   maxLength={20}
                   autoCapitalize="off"
+                  onChange={handleInputChange}
                 />
               </div>
-              <Button size="ms">중복확인</Button>
+              <Button size="ms" onClickEvent={idValidClickHandler}>
+                중복확인
+              </Button>
             </div>
+            {userNameMessage.message && (
+              <strong css={warningStyles({ color: userNameMessage.color })}>
+                {userNameMessage.message}
+              </strong>
+            )}
             <div css={formItemDivStyles} className="form-item password">
               <label htmlFor="password">비밀번호</label>
               <input
@@ -55,10 +105,14 @@ export default function JoinForm({ isSeller }) {
                 maxLength={20}
                 autoComplete="new-password"
               />
-              <span className="password-filled"></span>
+              {/*<span className="password-filled"></span>*/}
             </div>
+            {passwordError && (
+              <strong css={warningStyles} className="password-error">
+                멋진 아이디네요 :)
+              </strong>
+            )}
           </div>
-
           <div css={formListDivStyles} className="form-list">
             <div
               css={formItemDivStyles}
@@ -192,6 +246,16 @@ export default function JoinForm({ isSeller }) {
     </>
   );
 }
+
+const warningStyles = props => css`
+  display: block;
+  color: ${props.color === 'default' ? '#21BF48' : props.color};
+  font-family: Spoqa Han Sans Neo;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: normal;
+  margin-bottom: 12px;
+`;
 
 const formStyles = css({
   display: 'flex',

--- a/src/components/JoinForm/JoinForm.jsx
+++ b/src/components/JoinForm/JoinForm.jsx
@@ -4,10 +4,11 @@ import { css } from '@emotion/react';
 import Button from '../Button/Button';
 import NumDropDown from '../NumDropDown/NumDropDown';
 import CheckText from '../CheckText/CheckText';
-import { accountsValid } from '../../api/signupAPI';
+import { accountsValid, signup } from '../../api/signupAPI';
 import { useRecoilValue } from 'recoil';
 import checkOnIcon from '../../assets/images/icon-check-on.svg';
 import checkOffIcon from '../../assets/images/icon-check-off.svg';
+import { useNavigate } from 'react-router-dom';
 
 const INITIAL_VALUES = {
   username: '',
@@ -18,6 +19,7 @@ const INITIAL_VALUES = {
 };
 
 export default function JoinForm({ isSeller }) {
+  const navigate = useNavigate();
   const [isChecked, setIsChecked] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
   const [values, setValues] = useState(INITIAL_VALUES);
@@ -38,6 +40,7 @@ export default function JoinForm({ isSeller }) {
     isSame: false,
   });
   const [phoneNumber, setPhoneNumber] = useState([firstPhoneNum, '', '']);
+  const [phoneNumberError, setPhoneNumberError] = useState(null);
 
   const phoneNumClickHandler = () => {
     setIsClicked(!isClicked);
@@ -213,9 +216,22 @@ export default function JoinForm({ isSeller }) {
     handleChange('phone_number', nextPhoneNumber.join(''));
   };
 
-  const handleSubmit = event => {
+  const handleSubmit = async event => {
     event.preventDefault();
     console.log('가입하기');
+
+    try {
+      const response = await signup(values);
+      console.log(response);
+      console.log(response.statusText); // Created
+      const { name } = response.data;
+      navigate(`/welcome/${name}`);
+    } catch (e) {
+      // console.error(e);
+      const failMessage = e.response?.data?.phone_number[0];
+      setPhoneNumberError(failMessage);
+      console.log(failMessage);
+    }
   };
 
   useEffect(() => {
@@ -438,6 +454,11 @@ export default function JoinForm({ isSeller }) {
                   onChange={handleChangePhoneNumber}
                 />
               </div>
+              {phoneNumberError && (
+                <strong css={warningStyles({ color: '#EB5757' })}>
+                  {phoneNumberError}
+                </strong>
+              )}
             </div>
           </div>
 

--- a/src/components/JoinForm/JoinForm.jsx
+++ b/src/components/JoinForm/JoinForm.jsx
@@ -39,6 +39,16 @@ export default function JoinForm({ isSeller }) {
     handleChange(name, value);
   };
 
+  const confirmPassword = event => {
+    handleInputChange(event);
+    const currentInputPassword2 = event.target.value;
+    if (values.password !== currentInputPassword2) {
+      setPasswordError('비밀번호가 일치하지 않습니다.');
+    } else {
+      setPasswordError(null);
+    }
+  };
+
   const idValidClickHandler = event => {
     console.log('이메일 계정 검증');
     userIdValid();
@@ -93,23 +103,28 @@ export default function JoinForm({ isSeller }) {
                 name="password"
                 maxLength={20}
                 autoComplete="new-password"
+                onChange={handleInputChange}
               />
               <span className="password-filled"></span>
             </div>
             <div css={formItemDivStyles} className="form-item check-password">
-              <label htmlFor="password">비밀번호 재확인</label>
+              <label htmlFor="password2">비밀번호 재확인</label>
               <input
                 type="password"
-                id="password"
-                name="password"
+                id="password2"
+                name="password2"
                 maxLength={20}
                 autoComplete="new-password"
+                onChange={confirmPassword}
               />
               {/*<span className="password-filled"></span>*/}
             </div>
             {passwordError && (
-              <strong css={warningStyles} className="password-error">
-                멋진 아이디네요 :)
+              <strong
+                css={warningStyles({ color: '#EB5757' })}
+                className="password-error"
+              >
+                {passwordError}
               </strong>
             )}
           </div>

--- a/src/components/MoreList/MoreList.jsx
+++ b/src/components/MoreList/MoreList.jsx
@@ -4,14 +4,17 @@ import { css } from '@emotion/react';
 
 export default function MoreList({ itemType = 'login' }) {
   const items = {
-    login: ['회원가입', '비밀번호 찾기'],
+    login: [
+      { title: '회원가입', url: '/signup' },
+      { title: '비밀번호 찾기', url: '/#' },
+    ],
     footer: [
-      '호두샵 소개',
-      '이용약관',
-      '개인정보처리방침',
-      '전자금융거래약관',
-      '청소년보호정책',
-      '제휴문의',
+      { title: '호두샵 소개', url: '/#' },
+      { title: '이용약관', url: '/#' },
+      { title: '개인정보처리방침', url: '/#' },
+      { title: '전자금융거래약관', url: '/#' },
+      { title: '청소년보호정책', url: '/#' },
+      { title: '제휴문의', url: '/#' },
     ],
   };
 
@@ -19,13 +22,13 @@ export default function MoreList({ itemType = 'login' }) {
     <ul css={itemType === 'login' ? loginListStyles : footerListStyles}>
       {items[itemType].map(item => {
         return (
-          <li key={item} css={liStyles}>
-            {item === '개인정보처리방침' ? (
+          <li key={item.title} css={liStyles}>
+            {item.title === '개인정보처리방침' ? (
               <a href="/#">
-                <strong>{item}</strong>
+                <strong>{item.title}</strong>
               </a>
             ) : (
-              <a href="/#">{item}</a>
+              <a href={item.url}>{item.title}</a>
             )}
           </li>
         );

--- a/src/components/NumDropDown/NumDropDown.jsx
+++ b/src/components/NumDropDown/NumDropDown.jsx
@@ -2,36 +2,41 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-export default function NumDropDown() {
+export default function NumDropDown({ onClick, setIsClicked }) {
+  const handleItemClick = event => {
+    // console.log(event.target.innerText);
+    onClick(event.target.innerText);
+    setIsClicked(false);
+  };
   return (
     <ul css={ulStyles} role="menu" id="phoneStart" className="num-list">
       <li role="presentation">
-        <button type="button" role="menuitem">
+        <button type="button" role="menuitem" onClick={handleItemClick}>
           010
         </button>
       </li>
       <li role="presentation">
-        <button type="button" role="menuitem">
+        <button type="button" role="menuitem" onClick={handleItemClick}>
           011
         </button>
       </li>
       <li role="presentation">
-        <button type="button" role="menuitem">
+        <button type="button" role="menuitem" onClick={handleItemClick}>
           016
         </button>
       </li>
       <li role="presentation">
-        <button type="button" role="menuitem">
+        <button type="button" role="menuitem" onClick={handleItemClick}>
           017
         </button>
       </li>
       <li role="presentation">
-        <button type="button" role="menuitem">
+        <button type="button" role="menuitem" onClick={handleItemClick}>
           018
         </button>
       </li>
       <li role="presentation">
-        <button type="button" role="menuitem">
+        <button type="button" role="menuitem" onClick={handleItemClick}>
           019
         </button>
       </li>


### PR DESCRIPTION
## 변경 사항
**회원가입 페이지**

- API를 연결하여 구매회원 회원가입 기능 구현
  - 회원가입 할 때는 모든 입력을 완료하고 동의하기 체크를 눌러야만 회원가입이 가능합니다.
    - 비밀번호는 8자 이상, 영소문자를 포함해야 합니다.
    - 핸드폰 번호는 010으로 시작하는 10~11자리 숫자로만 이루어져 있습니다.
  - 회원 정보 입력 후 회원가입 버튼을 누르면 로그인 페이지로 이동합니다.
  - 아이디의 중복 확인 버튼을 눌렀을 때 중복이 된다면 입력창 아래에 경고 문구가 나타납니다.
  - 구매회원
  - 구매 회원 가입 탭을 누르고, 모든 입력을 마친 뒤(이용약관 체크박스 포함) 가입하기 버튼을 누르면 구매자로 회원가입이 됩니다.
 
이슈번호:  #55 
